### PR TITLE
Update DItto Download Recipe

### DIFF
--- a/Ditto/Ditto.download.recipe
+++ b/Ditto/Ditto.download.recipe
@@ -17,13 +17,11 @@
 	<array>
 		<dict>
 			<key>Processor</key>
-			<string>URLTextSearcher</string>
+			<string>SparkleUpdateInfoProvider</string>
 			<key>Arguments</key>
 			<dict>
-				<key>url</key>
-				<string>https://www.airsquirrels.com/ditto/download/</string>
-				<key>re_pattern</key>
-				<string>(?P&lt;url&gt;https:\/\/download\.airsquirrels\.com\/Ditto\/App\/Mac\/Ditto-[0-9\.]+dmg)</string>
+				<key>appcast_url</key>
+				<string>https://updates.goditto.com/DittoConnect/Mac/</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Update Ditto download recipe to use Sparkle Feed instead of regex to check for new versions